### PR TITLE
fix: Fix version of svenstaro/upload-release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
             /repos/wulfland/package-recipe/dependency-graph/sbom > sbom.json
 
       - name: Upload SBoM to release
-        uses: svenstaro/upload-release-action@v2.7.0
+        uses: svenstaro/upload-release-action@v2
         with:
           file: sbom.json
           asset_name: SBoM


### PR DESCRIPTION
The version of the tag does not follow the release.
Take the correct tag version.
