### PR TITLE
build: Cache npm dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,23 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: true
 
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: echo "dir=$(npm config get cache)" >> "${GITHUB_OUTPUT}"
+
+      - uses: actions/cache@v3
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: List the state of node modules
+        if: ${{ steps.npm-cache.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        run: npm list
+
       - name: Install dependencies
         run: npm install
 


### PR DESCRIPTION
Get the npm cache directory and save the dependencies on the cache
for the package-lock.json file.
