### PR TITLE
build: Publish package in publish job in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,10 +130,34 @@ jobs:
         with:
           useConfigFile: true
      
+      # If we use a token or app instead of the GITHUB_TOKEN, the release
+      # would trigger the other workflow. As we are using the GITHUB_TOKEN
+      # we manually have to publish the package.
+      # In a real-world scenario we would put the logic in a reusable workflow or
+      # composite action.
       - name: Create a new release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/wulfland/package-recipe/dependency-graph/sbom > sbom.json
           gh release create ${{ env.GITVERSION_SEMVER }} --generate-notes
-
+          gh release upload ${{ env.GITVERSION_SEMVER }} sbom.json --clobber
     
+      - name: 'Change NPM version'
+        uses: reedyuk/npm-version@1.2.2
+        with:
+          version: $GITVERSION_SEMVER
+  
+      - name: Install dependencies
+        run: npm install
+    
+      - name: Run tests
+        run: npm test
+            
+      - name: Publish package 
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
In the publish job in the ci.yml workflow, we create a new release using
the GitHub CLI. As we are using the GITHUB_TOKEN, this will not trigger
the release.yml workflow. I copied the logic to ci.yml. In a real-world
application, it would be a composite action or reusable workflow.
