### PR TITLE
fix: Add setup-node step to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,11 @@ jobs:
           gh release create ${{ env.GITVERSION_SEMVER }} --generate-notes
           gh release upload ${{ env.GITVERSION_SEMVER }} sbom.json --clobber
     
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 21.x
+          registry-url: https://npm.pkg.github.com/
+
       - name: 'Change NPM version'
         uses: reedyuk/npm-version@1.2.2
         with:


### PR DESCRIPTION
Adding the setup-node step to ci.yml in th epublish job to correctly set
the registry to publish the package.
