### PR TITLE
fix: Add write permission for packages to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adding the missing permission to write to packages to the publish job in
ci.yml
